### PR TITLE
INTERNAL: Modify by JDK 21 lint

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -185,7 +185,7 @@ import net.spy.memcached.util.BTreeUtil;
  *
  * }</pre>
  */
-public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClientIF {
+public final class ArcusClient extends FrontCacheMemcachedClient implements ArcusClientIF {
   private static String VERSION = null;
   private static final Object VERSION_LOCK = new Object();
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusClient.class);

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.util.ArcusReplKetamaNodeLocatorConfiguration;
 
-public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator {
+public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaGroups;
   private final HashMap<String, MemcachedReplicaGroup> allGroups;

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -47,7 +47,7 @@ import org.apache.zookeeper.ZooKeeper;
  * memcached server in the remote machine. It also changes the
  * previous ketama node
  */
-public class CacheManager extends SpyThread implements Watcher,
+public final class CacheManager extends SpyThread implements Watcher,
         CacheMonitor.CacheMonitorListener, MigrationMonitor.MigrationMonitorListener {
   private static final String ARCUS_BASE_CACHE_LIST_ZPATH = "/arcus/cache_list/";
 

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -31,7 +31,7 @@ import org.apache.zookeeper.ZooKeeper;
  * CacheMonitor monitors the changes of the cache server list
  * in the ZooKeeper node{@code (/arcus/cache_list/<service_code>)}.
  */
-public class CacheMonitor extends SpyObject implements Watcher,
+public final class CacheMonitor extends SpyObject implements Watcher,
         ChildrenCallback {
 
   private final ZooKeeper zk;

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -78,7 +78,7 @@ public class ConnectionFactoryBuilder {
 
   private int maxFrontCacheElements = DefaultConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
   private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
-  private String frontCacheName = "ArcusFrontCache_" + this.hashCode();
+  private String frontCacheName;
   private boolean frontCacheCopyOnRead = DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_READ;
   private boolean frontCacheCopyOnWrite =
       DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
@@ -632,6 +632,9 @@ public class ConnectionFactoryBuilder {
 
       @Override
       public String getFrontCacheName() {
+        if (frontCacheName == null) {
+          frontCacheName = "ArcusFrontCache_" + this.hashCode();
+        }
         return frontCacheName;
       }
 

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -190,6 +190,7 @@ public class MemcachedClient extends SpyThread
    * @param addrs the socket addresses
    * @throws IOException if connections cannot be established
    */
+  @SuppressWarnings("this-escape")
   public MemcachedClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)
           throws IOException {
     if (cf == null) {

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -18,7 +18,7 @@
 /* ENABLE_REPLICATION if */
 package net.spy.memcached;
 
-public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
+public final class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
 
   public MemcachedReplicaGroupImpl(final MemcachedNode node) {
     super(getGroupNameFromNode(node));

--- a/src/main/java/net/spy/memcached/MigrationMonitor.java
+++ b/src/main/java/net/spy/memcached/MigrationMonitor.java
@@ -33,7 +33,7 @@ import org.apache.zookeeper.data.Stat;
  * MigrationMonitor monitors the changes of the cloud_stat
  * in the ZooKeeper node{@code (/arcus/cloud_stat/<service_code>)}.
  */
-public class MigrationMonitor extends SpyObject implements Watcher {
+public final class MigrationMonitor extends SpyObject implements Watcher {
 
   private final ZooKeeper zk;
 

--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -13,7 +13,7 @@ import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 
-public class AuthThread extends SpyThread {
+public final class AuthThread extends SpyThread {
 
   private final MemcachedConnection conn;
   private final AuthDescriptor authDescriptor;

--- a/src/main/java/net/spy/memcached/compat/SpyObject.java
+++ b/src/main/java/net/spy/memcached/compat/SpyObject.java
@@ -11,7 +11,7 @@ import net.spy.memcached.compat.log.LoggerFactory;
  */
 public class SpyObject extends Object {
 
-  private transient Logger logger = null;
+  protected transient Logger logger = null;
 
   /**
    * Get an instance of SpyObject.

--- a/src/main/java/net/spy/memcached/compat/SyncThread.java
+++ b/src/main/java/net/spy/memcached/compat/SyncThread.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CyclicBarrier;
 /**
  * Thread that invokes a callable multiple times concurrently.
  */
-public class SyncThread<T> extends SpyThread {
+public final class SyncThread<T> extends SpyThread {
 
   private final Callable<T> callable;
   private final CyclicBarrier barrier;

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -30,7 +30,7 @@ import net.spy.memcached.ops.Operation;
 public class CheckedOperationTimeoutException extends TimeoutException {
 
   private static final long serialVersionUID = 5187393339735774489L;
-  private final Collection<Operation> operations;
+  private transient final Collection<Operation> operations;
 
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -40,6 +40,7 @@ import net.spy.memcached.ArcusReplNodeAddress;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.compat.log.LoggerFactory;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 
@@ -150,6 +151,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     this.opQueueMaxBlockTime = opQueueMaxBlockTime;
     shouldAuth = waitForAuth;
     isAsciiProtocol = asciiProtocol;
+    logger = LoggerFactory.getLogger(getClass());
     setupForAuth("init authentication");
   }
 
@@ -203,7 +205,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
         op.reset();
       } else {
         /* This case cannot happen. */
-        getLogger().warn("No buffer for current write op, removing");
+        logger.warn("No buffer for current write op, removing");
         removeCurrentWriteOp();
       }
     }
@@ -213,14 +215,14 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     while (hasReadOp()) {
       op = removeCurrentReadOp();
       if (op != getCurrentWriteOp()) {
-        getLogger().warn("Discarding partially completed op: %s", op);
+        logger.warn("Discarding partially completed op: %s", op);
         op.cancel(cause);
       }
     }
 
     while (shouldAuth && hasWriteOp()) {
       op = removeCurrentWriteOp();
-      getLogger().warn("Discarding partially completed op: %s", op);
+      logger.warn("Discarding partially completed op: %s", op);
       op.cancel(cause);
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -33,7 +33,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeFindPositionOperationImpl extends OperationImpl implements
+public final class BTreeFindPositionOperationImpl extends OperationImpl implements
         BTreeFindPositionOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -35,7 +35,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeFindPositionWithGetOperationImpl extends OperationImpl implements
+public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl implements
         BTreeFindPositionWithGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeGetBulkOperationImpl extends OperationImpl implements
+public final class BTreeGetBulkOperationImpl extends OperationImpl implements
         BTreeGetBulkOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeGetByPositionOperationImpl extends OperationImpl implements
+public final class BTreeGetByPositionOperationImpl extends OperationImpl implements
         BTreeGetByPositionOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
+public final class BTreeInsertAndGetOperationImpl extends OperationImpl implements
         BTreeInsertAndGetOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -39,7 +39,7 @@ import net.spy.memcached.util.BTreeUtil;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
+public final class BTreeSortMergeGetOperationImpl extends OperationImpl implements
         BTreeSortMergeGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
+public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
         BTreeSortMergeGetOperationOld {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -33,7 +33,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionBulkInsertOperationImpl extends OperationImpl
+public final class CollectionBulkInsertOperationImpl extends OperationImpl
         implements CollectionBulkInsertOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -37,7 +37,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to get exists item count from collection in a memcached server.
  */
-public class CollectionCountOperationImpl extends OperationImpl implements
+public final class CollectionCountOperationImpl extends OperationImpl implements
         CollectionCountOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -40,7 +40,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to create empty collection in a memcached server.
  */
-public class CollectionCreateOperationImpl extends OperationImpl
+public final class CollectionCreateOperationImpl extends OperationImpl
         implements CollectionCreateOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -40,7 +40,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to delete collection data in a memcached server.
  */
-public class CollectionDeleteOperationImpl extends OperationImpl
+public final class CollectionDeleteOperationImpl extends OperationImpl
         implements CollectionDeleteOperation {
 
   private static final OperationStatus DELETE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -37,7 +37,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to check membership of an item in collection in a memcached server.
  */
-public class CollectionExistOperationImpl extends OperationImpl
+public final class CollectionExistOperationImpl extends OperationImpl
         implements CollectionExistOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -43,7 +43,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve collection data in a memcached server.
  */
-public class CollectionGetOperationImpl extends OperationImpl
+public final class CollectionGetOperationImpl extends OperationImpl
         implements CollectionGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -42,7 +42,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionInsertOperationImpl extends OperationImpl
+public final class CollectionInsertOperationImpl extends OperationImpl
         implements CollectionInsertOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -38,7 +38,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to incr/decr item value from collection in a memcached server.
  */
-public class CollectionMutateOperationImpl extends OperationImpl implements
+public final class CollectionMutateOperationImpl extends OperationImpl implements
         CollectionMutateOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -31,7 +31,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class CollectionPipedExistOperationImpl extends OperationImpl implements
+public final class CollectionPipedExistOperationImpl extends OperationImpl implements
         CollectionPipedExistOperation {
 
   private static final OperationStatus EXIST_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionPipedInsertOperationImpl extends OperationImpl
+public final class CollectionPipedInsertOperationImpl extends OperationImpl
         implements CollectionPipedInsertOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to update collection data in a memcached server.
  */
-public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
+public final class CollectionPipedUpdateOperationImpl extends OperationImpl implements
         CollectionPipedUpdateOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -39,7 +39,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to update collection data in a memcached server.
  */
-public class CollectionUpdateOperationImpl extends OperationImpl implements
+public final class CollectionUpdateOperationImpl extends OperationImpl implements
         CollectionUpdateOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
@@ -25,7 +25,7 @@ import net.spy.memcached.ops.OperationCallback;
 /**
  * Operation for ascii concatenations.
  */
-public class ConcatenationOperationImpl extends BaseStoreOperationImpl
+public final class ConcatenationOperationImpl extends BaseStoreOperationImpl
         implements ConcatenationOperation {
 
   private final ConcatenationType concatType;

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -9,7 +9,7 @@ import net.spy.memcached.ops.GetOperation;
 /**
  * Operation for retrieving data.
  */
-public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
+public final class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
 
   private static final String CMD = "mget";
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
@@ -9,7 +9,7 @@ import net.spy.memcached.ops.GetsOperation;
 /**
  * Operation for retrieving data.
  */
-public class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
+public final class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
 
   private static final String CMD = "mgets";
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
 
-public class OptimizedSetImpl extends OperationImpl implements Operation {
+public final class OptimizedSetImpl extends OperationImpl implements Operation {
 
   private static final OperationCallback NOOP_CALLBACK = new NoopCallback();
 

--- a/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
@@ -347,7 +347,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
     private static final long serialVersionUID = 8942558579188233740L;
 
     private final int i;
-    private final List<String> list;
+    private final ArrayList<String> list;
 
     public UserDefinedClass() {
       this.i = 100;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
jdk 21 lint 경고를 해결하였습니다. 
경고를 나누어 진행하려다. 다른 한쪽의 경고가 너무 적어(2개) 합쳐서 진행하였습니다.

### possible 'this' escape before subclass is fully initialized

위는 아직 final 클래스가 아닌 클래스에 대하여 초기화가 끝나지 않았을때, 다른 클래스에서 해당 클래스를 참조하는 경우에 발생합니다.
이때 초기화가 끝난다는것은 생성자 호출이 끝났을때를 의미합니다.

따라서 경고를 해결하기 위해서는 
1. final class 로 선언
2. 생성자가 끝난 후 다른 함수에서 this 를 외부로 넘기는 메서드를 호출합니다.
3. 경고를 일으키는 함수에서 하는 일을 생성자에서 합니다. (부모클래스의 필드 초기화)

현재 문제가 발생하는 코드의 타입은 3가지 입니다.

1. 다른 클래스에 상속하지 않는 클래스에서 경고가 발생
2. 상속을 하는 중이며 상위 클래스의 필드를 자식 클래스의 생성자에서 set 함수를 호출하여 초기화 경우 (상위 클래스 필드 초기화)
3. 상속을 하는 중이며 단순 필드 초기화가 아닌 this 참조하는 경우

현재 해결한 방안

1 의 경우는 다른 클래스에 상속하지 않기 때문에 `final class` 선언으로 해결하였습니다.
2 의 경우는 자식 생성자에서 부모 클래스의 필드를 초기화 하기 위해 `protected` 를 활용하였습니다.
3 의 경우에는 `SuppressWarning()` 을 활용하였습니다.
https://github.com/jam2in/arcus-works/issues/568#issuecomment-2345538152

### non-transient instance field of a serializable class declared with a non-serializable type

위는 직렬화 가능 여부가 명확하지 않아 발생하는 경고 입니다.

`CheckedOperationTimeoutException` 에서는 해당 필드를 직렬화 하지 않아도 잘 동작하여 `transient` 를 활용했습니다. (직렬화 무시)
`VariousTypeTest` 에서는 직렬화 가능한 명확한 타입인 ArrayList 를 활용하였습니다.

test 는 모두 잘 동작합니다.